### PR TITLE
last changes broke the "bar not clickable" fixes again 

### DIFF
--- a/EazeGraphLibrary/src/main/java/org/eazegraph/lib/charts/BaseBarChart.java
+++ b/EazeGraphLibrary/src/main/java/org/eazegraph/lib/charts/BaseBarChart.java
@@ -358,17 +358,21 @@ public abstract class BaseBarChart extends BaseChart {
                 performClick();
                 result = true;
 
-                float newX = event.getX();
-                float newY = event.getY();
-                int   counter = 0;
+                if (mListener == null) {
+                    // we're not interested in clicks on individual bars here
+                    BaseBarChart.this.onTouchEvent(event);
+                } else {
+                    float newX = event.getX();
+                    float newY = event.getY();
+                    int   counter = 0;
 
-                for (RectF rectF : getBarBounds()) {
-                    if (Utils.intersectsPointWithRectF(rectF, newX, newY)) {
-                        if (mListener != null) {
+                    for (RectF rectF : getBarBounds()) {
+                        if (Utils.intersectsPointWithRectF(rectF, newX, newY)) {
                             mListener.onBarClicked(counter);
+                            break; // no need to check other bars
                         }
+                        counter++;
                     }
-                    counter++;
                 }
             }
 


### PR DESCRIPTION
...as BarChart::onTouchEvent was never called. In my app, I'm not interested in clicks on individual bars, but on the graph as a whole (so even clicks above a bar for example). Last implementation only called BaseBarChart::Graph::performClick which called Graph.super.performClick (=View::performClick, but not the BarChart::onClick)
