### PR TITLE
Remove attributes from the application declaration

### DIFF
--- a/EazeGraphLibrary/src/main/AndroidManifest.xml
+++ b/EazeGraphLibrary/src/main/AndroidManifest.xml
@@ -1,11 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.eazegraph.lib">
 
-    <application android:allowBackup="true"
-        android:label="@string/app_name"
-        android:icon="@drawable/ic_launcher"
->
-
+    <application>
     </application>
 
 </manifest>


### PR DESCRIPTION
The compilation failed if the app overwrote the allowBackup, label or icon attribute.

The library shouldn't define them, as they are application specific values.
