### PR TITLE
Fix allowing chart legend colour to be changed

### DIFF
--- a/EazeGraphLibrary/src/main/java/org/eazegraph/lib/charts/BaseBarChart.java
+++ b/EazeGraphLibrary/src/main/java/org/eazegraph/lib/charts/BaseBarChart.java
@@ -261,7 +261,7 @@ public abstract class BaseBarChart extends BaseChart {
         mGraphPaint.setStyle(Paint.Style.FILL);
 
         mLegendPaint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.LINEAR_TEXT_FLAG);
-        mLegendPaint.setColor(DEF_LEGEND_COLOR);
+        mLegendPaint.setColor(mLegendColor);
         mLegendPaint.setTextSize(mLegendTextSize);
         mLegendPaint.setStrokeWidth(2);
         mLegendPaint.setStyle(Paint.Style.FILL);

--- a/EazeGraphLibrary/src/main/java/org/eazegraph/lib/charts/PieChart.java
+++ b/EazeGraphLibrary/src/main/java/org/eazegraph/lib/charts/PieChart.java
@@ -611,7 +611,7 @@ public class PieChart extends BaseChart {
         mGraphPaint  = new Paint(Paint.ANTI_ALIAS_FLAG);
         mLegendPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
         mLegendPaint.setTextSize(mLegendTextSize);
-        mLegendPaint.setColor(DEF_LEGEND_COLOR);
+        mLegendPaint.setColor(mLegendColor);
         mLegendPaint.setStyle(Paint.Style.FILL);
 
         mValuePaint = new Paint(Paint.ANTI_ALIAS_FLAG);


### PR DESCRIPTION
This resolves half of the bug reported in #30 
The text colour of the legend can now be set using `setLegendColor` as expected