### PR TITLE
Crash fix

### DIFF
--- a/EazeGraphLibrary/src/main/java/org/eazegraph/lib/charts/ValueLineChart.java
+++ b/EazeGraphLibrary/src/main/java/org/eazegraph/lib/charts/ValueLineChart.java
@@ -1047,7 +1047,9 @@ public class ValueLineChart extends BaseChart {
             mLastFocusX = focusX;
             mLastFocusY = focusY;
 
-            calculateValueTextHeight();
+            if(mFocusedPoint != null) {
+                calculateValueTextHeight();
+            }
             invalidateGlobal();
 
             return true;


### PR DESCRIPTION
Fixed a crash that was caused by scaling the chart when egShowValueIndicator is set to false.

mFocusedPoint is null when there is no value indicator which causes a NullPointerException inside calculateValueTextHeight()